### PR TITLE
Fix teacher subject note bar

### DIFF
--- a/src/components/TheLecturerSearchCard.vue
+++ b/src/components/TheLecturerSearchCard.vue
@@ -22,16 +22,22 @@
       <div class="text-body-2">
         <v-chip-group>
           <v-chip
-            v-for="subject in lecturer.subjects"
+            v-for="(subject, index) in lecturer.subjects.slice(0, 2)"
             :key="subject"
             :text="subject"
             size="small"
           ></v-chip>
+          <v-chip
+            v-if="lecturer.subjects.length > 2"
+            :key="'more'"
+            size="small"
+          >
+            еще {{ lecturer.subjects.length - 2 }}
+          </v-chip>
         </v-chip-group>
         <div>отзывы: {{ lecturer.comments?.length ?? "—" }}</div>
         <div>
-          оценка: {{ lecturer.mark_general > 0 ? "+" : ""
-          }}{{ lecturer.mark_general?.toFixed(2) ?? "—" }}
+          оценка: {{ lecturer.mark_general > 0 ? "+" : "" }}{{ lecturer.mark_general?.toFixed(2) ?? "—" }}
         </div>
       </div>
     </template>

--- a/src/components/TheLecturerSearchCard.vue
+++ b/src/components/TheLecturerSearchCard.vue
@@ -20,7 +20,7 @@
         {{ lecturer.first_name }} {{ lecturer.middle_name }}
       </div>
       <div class="text-body-2">
-        <v-chip-group>
+        <v-chip-group v-if="lecturer.subjects && lecturer.subjects.length > 0">
           <v-chip
             v-for="subject in lecturer.subjects.slice(0, 2)"
             :key="subject"
@@ -35,6 +35,8 @@
             еще {{ lecturer.subjects.length - 2 }}
           </v-chip>
         </v-chip-group>
+        <div v-else-if="lecturer.subjects === null"> </div>
+        <div v-else>Нет предметов</div>
         <div>отзывы: {{ lecturer.comments?.length ?? "—" }}</div>
         <div>
           оценка: {{ lecturer.mark_general > 0 ? "+" : ""
@@ -68,6 +70,7 @@ const props = defineProps({
   lecturer: { type: Object, required: true },
   photo: { type: String, required: true },
 });
+
 
 function toReviewPage() {
   router.push({ path: "review", query: { lecturer_id: props.lecturer.id } });

--- a/src/components/TheLecturerSearchCard.vue
+++ b/src/components/TheLecturerSearchCard.vue
@@ -22,7 +22,7 @@
       <div class="text-body-2">
         <v-chip-group>
           <v-chip
-            v-for="(subject, index) in lecturer.subjects.slice(0, 2)"
+            v-for="subject in lecturer.subjects.slice(0, 2)"
             :key="subject"
             :text="subject"
             size="small"
@@ -37,7 +37,8 @@
         </v-chip-group>
         <div>отзывы: {{ lecturer.comments?.length ?? "—" }}</div>
         <div>
-          оценка: {{ lecturer.mark_general > 0 ? "+" : "" }}{{ lecturer.mark_general?.toFixed(2) ?? "—" }}
+          оценка: {{ lecturer.mark_general > 0 ? "+" : ""
+          }}{{ lecturer.mark_general?.toFixed(2) ?? "—" }}
         </div>
       </div>
     </template>


### PR DESCRIPTION
## Изменения
Изменил статус-бар с предметами в меню выбора и поиска преподавателя

## Детали реализации
-Добавил проверку на null в lecturer.subjects;
-При наличии одного или двух предметов у преподавателя они выводятся полностью, если предметов больше выводится "еще n-2", где n - число предметов преподавателя;
Все изменения сделаны в TheLecturerSearchCard.vue

## Check-List
<!-- После сохранения у следующих полей появятся галочки, которые нужно проставить мышкой -->
- [x] Вы проверили свой код перед отправкой запроса?
- [ ] Вы написали тесты к реализованным функциям?
- [x] Вы не забыли применить форматирование `black` и `isort` для _Back-End_ или `Prettier` для _Front-End_?
