### PR TITLE
добавила local_storage к отзывам

### DIFF
--- a/src/models/LocalStorage.ts
+++ b/src/models/LocalStorage.ts
@@ -2,6 +2,7 @@ export enum LocalStorageItem {
 	Token = 'token',
 	TokenScopes = 'token-scopes',
 	UserId = 'user-id',
+	ReviewList = 'review-list',
 }
 
 export class LocalStorage {

--- a/src/models/review.ts
+++ b/src/models/review.ts
@@ -1,0 +1,11 @@
+export interface Review {
+	id: string;
+	subject: string;
+	text: string;
+
+	mark_kindness: number;
+	mark_freebie: number;
+	mark_clarity: number;
+
+	is_anonymous: boolean;
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,1 +1,2 @@
+export { useReviewStore } from './reviewStore';
 export { useProfileStore } from './profileStore';

--- a/src/store/reviewStore.ts
+++ b/src/store/reviewStore.ts
@@ -1,0 +1,47 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import { LocalStorage, LocalStorageItem } from '@/models/LocalStorage';
+import type { Review } from '@/models/review';
+
+export const useReviewStore = defineStore('review', () => {
+	const reviewList = ref<Review[]>([]);
+
+	const loadReviews = () => {
+		const stored = LocalStorage.getObject<Review[]>(LocalStorageItem.ReviewList);
+		reviewList.value = stored || [];
+	};
+
+	const getById = (id: string): Review | null => {
+		loadReviews();
+		return reviewList.value.find(review => review.id === id) || null;
+	};
+
+	const save = (id: string, fields: Omit<Review, 'id'>) => {
+		loadReviews();
+
+		const newReview: Review = { id, ...fields };
+		const index = reviewList.value.findIndex(r => r.id === id);
+
+		if (index >= 0) {
+			reviewList.value[index] = newReview;
+		} else {
+			reviewList.value.push(newReview);
+		}
+
+		LocalStorage.set(LocalStorageItem.ReviewList, reviewList.value);
+	};
+
+	const removeById = (id: string) => {
+		loadReviews();
+		reviewList.value = reviewList.value.filter(review => review.id !== id);
+		LocalStorage.set(LocalStorageItem.ReviewList, reviewList.value);
+	};
+
+	return {
+		reviewList,
+		loadReviews,
+		getById,
+		save,
+		removeById,
+	};
+});


### PR DESCRIPTION
## Изменения
Добавила возможность сохранения отзыва в локальное хранилище
При закрытии страницы с отзывом до его отправки, если заполнены все поля по отзыву, отзыв сохраняется в локальное хранилище. 
При открытии вкладки с отзывом о преподавателе, если есть в локальном хранилище сохраненный до этого отзыв, то он отобразится у пользователя.
При отправке отзыва из локального хранилища он удаляется, если до этого был туда сохранен.

## Детали реализации
- добавлен к модели localStorage новый ключ reviewlist
- добавлен новый тип данных для отзыва: Review
- написан новый стор для работы с отзывами: reviewStore, с методами loadreviews, getById, save, removeById
- на страницу отзывов ReviewPage.vue добавлена логика работы с локальным хранилищем с помощью Onmounted(), Onunmounted()

## Check-List
<!-- После сохранения у следующих полей появятся галочки, которые нужно проставить мышкой -->
- [x] Вы проверили свой код перед отправкой запроса?
- [x] Вы написали тесты к реализованным функциям?
- [x] Вы не забыли применить форматирование `black` и `isort` для _Back-End_ или `Prettier` для _Front-End_?
