### PR TITLE
Компактное отображение списка преподов Дубинушки

### DIFF
--- a/src/components/TheLecturerSearchCompactCard.vue
+++ b/src/components/TheLecturerSearchCompactCard.vue
@@ -13,13 +13,15 @@
         </template>
 
         <template #item.subjects="{ item }">
-            <v-chip v-for="(subject, idx) in (item.raw.subjects || []).slice(0, 2)" :key="idx" size="small"
-                class="mr-1 mb-1">
-                {{ subject }}
-            </v-chip>
-            <v-chip v-if="item.raw.subjects && item.raw.subjects.length > 2" size="small" variant="outlined">
-                еще {{ item.raw.subjects.length - 2 }}
-            </v-chip>
+            <template v-if="getFilteredSubjects(item.raw.subjects).length > 0">
+                <v-chip v-for="(subject, idx) in getFilteredSubjects(item.raw.subjects).slice(0, 2)" :key="idx"
+                    size="small" class="mr-1 mb-1">
+                    {{ subject }}
+                </v-chip>
+                <v-chip v-if="getFilteredSubjects(item.raw.subjects).length > 2" size="small" variant="outlined">
+                    еще {{ getFilteredSubjects(item.raw.subjects).length - 2 }}
+                </v-chip>
+            </template>
         </template>
 
         <template #item.comments="{ item }">
@@ -46,20 +48,25 @@ const props = defineProps({
 const emit = defineEmits(['lecturerClick']);
 
 const headers = [
-    { title: '№', key: 'rating', width: '50px', sortable: false },
+    { title: '#', key: 'rating', width: '50px', sortable: false },
     { title: 'ФИО', key: 'fullName', sortable: false },
     { title: 'Предметы', key: 'subjects', sortable: false },
     { title: 'Отзывы', key: 'comments', align: 'center', sortable: false },
     { title: 'Оценка', key: 'mark_general', align: 'center', sortable: false }
 ];
 
-// Преобразование lecturers в нужный формат
+// Преобразую lecturers в нужный формат
 const tableItems = computed(() => {
     if (!props.lecturers) return [];
     return props.lecturers.map(lecturer => ({
         raw: lecturer
     }));
 });
+
+function getFilteredSubjects(subjects: string[] | null): string[] {
+    if (!subjects) return [];
+    return subjects.filter(subject => subject !== null);
+}
 
 function handleRowClick(_event: any, { item }: any) {
     emit('lecturerClick', item.raw.id);
@@ -79,6 +86,11 @@ function getMarkColor(mark: number) {
 <style scoped>
 .lecturer-table {
     cursor: pointer;
+}
+
+:deep(.lecturer-table thead th) {
+    font-weight: bold;
+    background-color: #f5f5f5;
 }
 
 :deep(.lecturer-table tbody tr:hover) {

--- a/src/components/TheLecturerSearchCompactCard.vue
+++ b/src/components/TheLecturerSearchCompactCard.vue
@@ -1,0 +1,98 @@
+<template>
+    <v-data-table :headers="headers" :items="[processedLecturer]" :search="search" :items-per-page="itemsPerPage"
+        item-value="id" density="compact" hide-default-header hide-default-footer>
+
+        <template #item.rating="{ item }">
+            <v-chip size="small">
+                {{ item.rating }}
+            </v-chip>
+        </template>
+
+        <template #item.name="{ item }">
+            <div>
+                <div class="text-h6">{{ item.last_name }}</div>
+                <div class="text-caption">
+                    {{ item.first_name }} {{ item.middle_name }}
+                </div>
+            </div>
+        </template>
+
+        <template #item.subjects="{ item }">
+            <v-chip-group>
+                <v-chip v-for="subject in item.subjectsToShow.slice(0, 2)" :key="subject" size="small"
+                    variant="outlined">
+                    {{ subject }}
+                </v-chip>
+                <v-chip v-if="item.subjectsToShow.length > 2" size="small" variant="tonal">
+                    ещё +{{ item.subjectsToShow.length - 2 }}
+                </v-chip>
+            </v-chip-group>
+        </template>
+
+        <template #item.comments="{ item }">
+            {{ item.comments?.length || '—' }}
+        </template>
+
+        <template #item.mark_general="{ item }">
+            <v-rating :model-value="item.mark_general" half-increments readonly size="small" density="compact" />
+            <div class="text-caption">
+                {{ item.mark_general > 0 ? '+' : '' }}{{ item.mark_general?.toFixed(2) || '—' }}
+            </div>
+        </template>
+    </v-data-table>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, onMounted, onUnmounted } from 'vue'
+import { useDisplay } from 'vuetify'
+
+const { mobile } = useDisplay()
+
+const props = defineProps({
+    lecturer: { type: Object, required: true },
+    photo: { type: String, required: true },
+    rating: { type: Number, required: true },
+})
+
+const search = ref('')
+const itemsPerPage = ref(10)
+
+// Автоматическое определение количества элементов на странице
+const updateItemsPerPage = () => {
+    if (mobile.value) {
+        itemsPerPage.value = 5
+    } else {
+        // Рассчитываем, сколько элементов помещается на экране
+        const rowHeight = 60; // Предполагаемая высота строки
+        const tableHeaderHeight = 120; // Высота заголовка и поиска
+        const paginationHeight = 50; // Высота пагинации
+        const availableHeight = window.innerHeight - tableHeaderHeight - paginationHeight;
+        itemsPerPage.value = Math.max(1, Math.floor(availableHeight / rowHeight));
+    }
+}
+
+onMounted(() => {
+    updateItemsPerPage()
+    window.addEventListener('resize', updateItemsPerPage)
+})
+
+onUnmounted(() => {
+    window.removeEventListener('resize', updateItemsPerPage)
+})
+
+const headers = [
+    { title: 'Рейтинг', key: 'rating', width: '100px' },
+    { title: 'ФИО', key: 'name', sortable: true },
+    { title: 'Предметы', key: 'subjects' },
+    { title: 'Отзывы', key: 'comments', align: 'end', width: '100px' },
+    { title: 'Оценка', key: 'mark_general', align: 'end', width: '130px' }
+]
+
+const processedLecturer = computed(() => {
+    return {
+        ...props.lecturer,
+        rating: props.rating,
+        subjectsToShow: props.lecturer.subjects?.filter(item => item !== null) || []
+    }
+})
+</script>

--- a/src/components/TheLecturerSearchCompactCard.vue
+++ b/src/components/TheLecturerSearchCompactCard.vue
@@ -1,5 +1,5 @@
 <template>
-    <v-data-table :headers="headers" :items="tableItems" hide-default-header hide-default-footer disable-sort
+    <v-data-table :headers="headers" :items="tableItems" hide-default-footer disable-sort
         class="elevation-1 lecturer-table" @click:row="handleRowClick">
         <template #item.rating="{ index }">
             {{ ratings[index] }}
@@ -46,7 +46,7 @@ const props = defineProps({
 const emit = defineEmits(['lecturerClick']);
 
 const headers = [
-    { title: '#', key: 'rating', width: '50px', sortable: false },
+    { title: '№', key: 'rating', width: '50px', sortable: false },
     { title: 'ФИО', key: 'fullName', sortable: false },
     { title: 'Предметы', key: 'subjects', sortable: false },
     { title: 'Отзывы', key: 'comments', align: 'center', sortable: false },

--- a/src/components/TheLecturerSearchCompactCard.vue
+++ b/src/components/TheLecturerSearchCompactCard.vue
@@ -1,99 +1,121 @@
 <template>
-    <v-data-table :headers="headers" :items="tableItems" hide-default-footer disable-sort
-        class="elevation-1 lecturer-table" @click:row="handleRowClick">
-        <template #item.rating="{ index }">
-            {{ ratings[index] }}
-        </template>
+	<v-data-table
+		:headers="headers"
+		:items="tableItems"
+		hide-default-footer
+		disable-sort
+		class="elevation-1 lecturer-table"
+		@click:row="handleRowClick"
+	>
+		<template #[`item.rating`]="{ index }">
+			{{ ratings[index] }}
+		</template>
 
-        <template #item.fullName="{ item }">
-            <div>
-                <strong>{{ item.raw.last_name }}</strong>
-                {{ item.raw.first_name }} {{ item.raw.middle_name }}
-            </div>
-        </template>
+		<template #[`item.fullName`]="{ item }">
+			<div>
+				<strong>{{ item.raw.last_name }}</strong>
+				{{ item.raw.first_name }} {{ item.raw.middle_name }}
+			</div>
+		</template>
 
-        <template #item.subjects="{ item }">
-            <template v-if="getFilteredSubjects(item.raw.subjects).length > 0">
-                <v-chip v-for="(subject, idx) in getFilteredSubjects(item.raw.subjects).slice(0, 2)" :key="idx"
-                    size="small" class="mr-1 mb-1">
-                    {{ subject }}
-                </v-chip>
-                <v-chip v-if="getFilteredSubjects(item.raw.subjects).length > 2" size="small" variant="outlined">
-                    еще {{ getFilteredSubjects(item.raw.subjects).length - 2 }}
-                </v-chip>
-            </template>
-        </template>
+		<template #[`item.subjects`]="{ item }">
+			<template v-if="getFilteredSubjects(item.raw.subjects).length > 0">
+				<v-chip
+					v-for="(subject, idx) in getFilteredSubjects(item.raw.subjects).slice(0, 2)"
+					:key="idx"
+					size="small"
+					class="mr-1 mb-1"
+				>
+					{{ subject }}
+				</v-chip>
+				<v-chip v-if="getFilteredSubjects(item.raw.subjects).length > 2" size="small" variant="outlined">
+					еще {{ getFilteredSubjects(item.raw.subjects).length - 2 }}
+				</v-chip>
+			</template>
+		</template>
 
-        <template #item.comments="{ item }">
-            {{ item.raw.comments?.length || '—' }}
-        </template>
+		<template #[`item.comments`]="{ item }">
+			{{ item.raw.comments?.length || '—' }}
+		</template>
 
-        <template #item.mark_general="{ item }">
-            <v-avatar size="30" :color="getMarkColor(item.raw.mark_general)" class="white--text">
-                {{ formatMark(item.raw.mark_general) }}
-            </v-avatar>
-        </template>
-    </v-data-table>
+		<template #[`item.mark_general`]="{ item }">
+			<v-avatar size="30" :color="getMarkColor(item.raw.mark_general)" class="white--text">
+				{{ formatMark(item.raw.mark_general) }}
+			</v-avatar>
+		</template>
+	</v-data-table>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue';
 import { Lecturer } from '@/models';
 
+interface TableItem {
+	raw: Lecturer;
+}
+
+interface CustomDataTableHeader {
+	title: string;
+	key: string;
+	width?: string;
+	sortable?: boolean;
+	align?: 'start' | 'center' | 'end';
+}
+
 const props = defineProps({
-    lecturers: { type: Array as () => Lecturer[], required: true },
-    ratings: { type: Array as () => number[], required: true }
+	lecturers: { type: Array as () => Lecturer[], required: true },
+	ratings: { type: Array as () => number[], required: true },
 });
 
 const emit = defineEmits(['lecturerClick']);
 
-const headers = [
-    { title: '№', key: 'rating', width: '50px', sortable: false },
-    { title: 'ФИО', key: 'fullName', sortable: false },
-    { title: 'Предметы', key: 'subjects', sortable: false },
-    { title: 'Отзывы', key: 'comments', align: 'center', sortable: false },
-    { title: 'Оценка', key: 'mark_general', align: 'center', sortable: false }
+const headers: CustomDataTableHeader[] = [
+	{ title: '№', key: 'rating', width: '50px', sortable: false },
+	{ title: 'ФИО', key: 'fullName', sortable: false },
+	{ title: 'Предметы', key: 'subjects', sortable: false },
+	{ title: 'Отзывы', key: 'comments', align: 'center', sortable: false },
+	{ title: 'Оценка', key: 'mark_general', align: 'center', sortable: false },
 ];
 
-// Преобразую lecturers в нужный формат
+// Преобразуем lecturers в формат, понятный для v-data-table
 const tableItems = computed(() => {
-    if (!props.lecturers) return [];
-    return props.lecturers.map(lecturer => ({
-        raw: lecturer
-    }));
+	if (!props.lecturers) return [];
+	return props.lecturers.map(lecturer => ({
+		raw: lecturer,
+	}));
 });
 
-function getFilteredSubjects(subjects: string[] | null): string[] {
-    if (!subjects) return [];
-    return subjects.filter(subject => subject !== null);
+function getFilteredSubjects(subjects: string[] | null | undefined): string[] {
+	if (!subjects) return [];
+	return subjects.filter((subject): subject is string => subject !== null);
 }
 
-function handleRowClick(_event: any, { item }: any) {
-    emit('lecturerClick', item.raw.id);
+function handleRowClick(event: Event, { item }: { item: TableItem }) {
+	emit('lecturerClick', item.raw.id);
 }
 
-function formatMark(mark: number) {
-    if (!mark && mark !== 0) return '—';
-    return mark > 0 ? `+${mark.toFixed(1)}` : mark.toFixed(1);
+function formatMark(mark: number | null | undefined): string {
+	if (mark === null || mark === undefined) return '—';
+	return mark > 0 ? `+${mark.toFixed(1)}` : mark.toFixed(1);
 }
 
-function getMarkColor(mark: number) {
-    if (!mark && mark !== 0) return 'grey';
-    return mark > 0 ? 'green' : mark === 0 ? 'grey' : 'red';
+function getMarkColor(mark: number | null | undefined): string {
+	if (mark === null || mark === undefined) return 'grey';
+	return mark > 0 ? 'green' : mark === 0 ? 'grey' : 'red';
 }
 </script>
 
 <style scoped>
 .lecturer-table {
-    cursor: pointer;
+	cursor: pointer;
 }
 
 :deep(.lecturer-table thead th) {
-    font-weight: bold;
-    background-color: #f5f5f5;
+	font-weight: bold;
+	background-color: #f5f5f5;
 }
 
 :deep(.lecturer-table tbody tr:hover) {
-    background-color: rgb(0 0 0 / 4%);
+	background-color: rgb(0 0 0 / 4%);
 }
 </style>

--- a/src/components/TheLecturerSearchCompactCard.vue
+++ b/src/components/TheLecturerSearchCompactCard.vue
@@ -48,7 +48,7 @@ const props = defineProps({
 const emit = defineEmits(['lecturerClick']);
 
 const headers = [
-    { title: '#', key: 'rating', width: '50px', sortable: false },
+    { title: '№', key: 'rating', width: '50px', sortable: false },
     { title: 'ФИО', key: 'fullName', sortable: false },
     { title: 'Предметы', key: 'subjects', sortable: false },
     { title: 'Отзывы', key: 'comments', align: 'center', sortable: false },

--- a/src/pages/MainPage.vue
+++ b/src/pages/MainPage.vue
@@ -1,26 +1,26 @@
 <script async setup lang="ts">
 import { router } from '@/router';
-import { ref, Ref } from 'vue';
+import { ref, Ref, computed } from 'vue';
 import apiClient from '@/api';
 import { useProfileStore } from '@/store';
 import Placeholder from '@/assets/profile_image_placeholder.webp';
 import TheSearchBar from '@/components/TheSearchBar.vue';
-import TheLecturerSearchCard from '@/components/TheLecturerSearchCompactCard.vue';
+import TheLecturerSearchCard from '@/components/TheLecturerSearchCard.vue';
+import TheLecturerSearchCompactCard from '@/components/TheLecturerSearchCompactCard.vue';
 import { Lecturer, Order, OrderFromText, Subject } from '@/models';
 import { getPhoto } from '@/utils';
 import { useSearchStore } from '@/store/searchStore';
 
-// const
 const profileStore = useProfileStore();
 const searchStore = useSearchStore();
 const userAdmin = ref<boolean>(false);
 userAdmin.value = profileStore.isAdmin();
 const itemsPerPage = 10;
 
-// utils
+const isCompactView = ref(false);
+
 const totalPages: Ref<number> = ref(1);
 
-// search state
 const name = ref(searchStore.name);
 const subject: Ref<Subject> = ref(searchStore.subject);
 const order = ref(searchStore.order || 'по релевантности');
@@ -30,6 +30,12 @@ const page = ref(searchStore.page);
 
 const lecturers: Ref<Lecturer[] | undefined> = ref();
 const lecturersPhotos = ref<string[]>(Array<string>(itemsPerPage));
+
+// Вычисляем порядковые номера для компактного режима
+const lecturerRatings = computed(() => {
+	if (!lecturers.value) return [];
+	return lecturers.value.map((_, idx) => (page.value - 1) * itemsPerPage + idx + 1);
+});
 
 await loadLecturers();
 
@@ -87,31 +93,41 @@ async function changeAscOrder() {
 
 <template>
 	<v-container class="ma-0 py-2">
-		<v-data-iterator :items="lecturers" :items-per-page="itemsPerPage">
-			<template #header>
-				<TheSearchBar v-model:search-query="name" v-model:subject="subject" v-model:order="order"
-					:is-admin="userAdmin" :ascending="ascending" :page="page" @update:subject="filterLecturers"
-					@update:order="orderLecturers" @update:search-query="findLecturer"
-					@changed-asc-desc="changeAscOrder" />
-			</template>
+		<TheSearchBar v-model:search-query="name" v-model:subject="subject" v-model:order="order" :is-admin="userAdmin"
+			:ascending="ascending" :page="page" @update:subject="filterLecturers" @update:order="orderLecturers"
+			@update:search-query="findLecturer" @changed-asc-desc="changeAscOrder" />
 
-			<template #default="{ items }">
-				<TheLecturerSearchCard v-for="(item, idx) in items" :key="idx" :lecturer="item.raw"
-					:photo="lecturersPhotos[idx]" :rating="(page - 1) * itemsPerPage + idx + 1" class="py-0"
-					variant="elevated" @click="toLecturerPage(item.raw.id)" />
-			</template>
+		<!-- Обычный режим с карточками -->
+		<div v-if="!isCompactView">
+			<v-data-iterator :items="lecturers" :items-per-page="itemsPerPage">
+				<template #default="{ items }">
+					<TheLecturerSearchCard v-for="(item, idx) in items" :key="idx" :lecturer="item.raw"
+						:photo="lecturersPhotos[idx]" :rating="(page - 1) * itemsPerPage + idx + 1" class="py-0"
+						variant="elevated" @click="toLecturerPage(item.raw.id)" />
+				</template>
 
-			<template #no-data>
-				<div class="ma-2">Ничего не нашли :(</div>
-			</template>
+				<template #no-data>
+					<div class="ma-2">Ничего не нашли :(</div>
+				</template>
+			</v-data-iterator>
+		</div>
 
-			<template #footer>
-				<div v-if="lecturers && totalPages > 1">
-					<v-pagination v-model="page" active-color="primary" variant="elevated" :length="totalPages"
-						:total-visible="1" :show-first-last-page="true" ellipsis=""
-						@update:model-value="loadLecturers" />
-				</div>
-			</template>
-		</v-data-iterator>
+		<!-- Компактный режим с таблицей -->
+		<div v-else>
+			<TheLecturerSearchCompactCard v-if="lecturers && lecturers.length > 0" :lecturers="lecturers"
+				:ratings="lecturerRatings" @lecturer-click="toLecturerPage" />
+			<div v-else class="ma-2">Ничего не нашли :(</div>
+		</div>
+
+		<!-- Пагинация и переключатель режима -->
+		<div v-if="lecturers && totalPages > 1" class="d-flex align-center justify-center mt-4">
+			<v-btn icon @click="isCompactView = !isCompactView" class="mr-2"
+				:title="isCompactView ? 'Обычный вид' : 'Компактный вид'">
+				<v-icon>{{ isCompactView ? 'mdi-view-agenda' : 'mdi-table' }}</v-icon>
+			</v-btn>
+
+			<v-pagination v-model="page" active-color="primary" variant="elevated" :length="totalPages"
+				:total-visible="1" :show-first-last-page="true" ellipsis="" @update:model-value="loadLecturers" />
+		</div>
 	</v-container>
 </template>

--- a/src/pages/MainPage.vue
+++ b/src/pages/MainPage.vue
@@ -5,7 +5,7 @@ import apiClient from '@/api';
 import { useProfileStore } from '@/store';
 import Placeholder from '@/assets/profile_image_placeholder.webp';
 import TheSearchBar from '@/components/TheSearchBar.vue';
-import TheLecturerSearchCard from '@/components/TheLecturerSearchCard.vue';
+import TheLecturerSearchCard from '@/components/TheLecturerSearchCompactCard.vue';
 import { Lecturer, Order, OrderFromText, Subject } from '@/models';
 import { getPhoto } from '@/utils';
 import { useSearchStore } from '@/store/searchStore';
@@ -89,31 +89,16 @@ async function changeAscOrder() {
 	<v-container class="ma-0 py-2">
 		<v-data-iterator :items="lecturers" :items-per-page="itemsPerPage">
 			<template #header>
-				<TheSearchBar
-					v-model:search-query="name"
-					v-model:subject="subject"
-					v-model:order="order"
-					:is-admin="userAdmin"
-					:ascending="ascending"
-					:page="page"
-					@update:subject="filterLecturers"
-					@update:order="orderLecturers"
-					@update:search-query="findLecturer"
-					@changed-asc-desc="changeAscOrder"
-				/>
+				<TheSearchBar v-model:search-query="name" v-model:subject="subject" v-model:order="order"
+					:is-admin="userAdmin" :ascending="ascending" :page="page" @update:subject="filterLecturers"
+					@update:order="orderLecturers" @update:search-query="findLecturer"
+					@changed-asc-desc="changeAscOrder" />
 			</template>
 
 			<template #default="{ items }">
-				<TheLecturerSearchCard
-					v-for="(item, idx) in items"
-					:key="idx"
-					:lecturer="item.raw"
-					:photo="lecturersPhotos[idx]"
-					:rating="(page - 1) * itemsPerPage + idx + 1"
-					class="py-0"
-					variant="elevated"
-					@click="toLecturerPage(item.raw.id)"
-				/>
+				<TheLecturerSearchCard v-for="(item, idx) in items" :key="idx" :lecturer="item.raw"
+					:photo="lecturersPhotos[idx]" :rating="(page - 1) * itemsPerPage + idx + 1" class="py-0"
+					variant="elevated" @click="toLecturerPage(item.raw.id)" />
 			</template>
 
 			<template #no-data>
@@ -122,16 +107,9 @@ async function changeAscOrder() {
 
 			<template #footer>
 				<div v-if="lecturers && totalPages > 1">
-					<v-pagination
-						v-model="page"
-						active-color="primary"
-						variant="elevated"
-						:length="totalPages"
-						:total-visible="1"
-						:show-first-last-page="true"
-						ellipsis=""
-						@update:model-value="loadLecturers"
-					/>
+					<v-pagination v-model="page" active-color="primary" variant="elevated" :length="totalPages"
+						:total-visible="1" :show-first-last-page="true" ellipsis=""
+						@update:model-value="loadLecturers" />
 				</div>
 			</template>
 		</v-data-iterator>

--- a/src/pages/MainPage.vue
+++ b/src/pages/MainPage.vue
@@ -93,17 +93,33 @@ async function changeAscOrder() {
 
 <template>
 	<v-container class="ma-0 py-2">
-		<TheSearchBar v-model:search-query="name" v-model:subject="subject" v-model:order="order" :is-admin="userAdmin"
-			:ascending="ascending" :page="page" @update:subject="filterLecturers" @update:order="orderLecturers"
-			@update:search-query="findLecturer" @changed-asc-desc="changeAscOrder" />
+		<TheSearchBar
+			v-model:search-query="name"
+			v-model:subject="subject"
+			v-model:order="order"
+			:is-admin="userAdmin"
+			:ascending="ascending"
+			:page="page"
+			@update:subject="filterLecturers"
+			@update:order="orderLecturers"
+			@update:search-query="findLecturer"
+			@changed-asc-desc="changeAscOrder"
+		/>
 
 		<!-- Обычный режим с карточками -->
 		<div v-if="!isCompactView">
 			<v-data-iterator :items="lecturers" :items-per-page="itemsPerPage">
 				<template #default="{ items }">
-					<TheLecturerSearchCard v-for="(item, idx) in items" :key="idx" :lecturer="item.raw"
-						:photo="lecturersPhotos[idx]" :rating="(page - 1) * itemsPerPage + idx + 1" class="py-0"
-						variant="elevated" @click="toLecturerPage(item.raw.id)" />
+					<TheLecturerSearchCard
+						v-for="(item, idx) in items"
+						:key="idx"
+						:lecturer="item.raw"
+						:photo="lecturersPhotos[idx]"
+						:rating="(page - 1) * itemsPerPage + idx + 1"
+						class="py-0"
+						variant="elevated"
+						@click="toLecturerPage(item.raw.id)"
+					/>
 				</template>
 
 				<template #no-data>
@@ -114,20 +130,36 @@ async function changeAscOrder() {
 
 		<!-- Компактный режим с таблицей -->
 		<div v-else>
-			<TheLecturerSearchCompactCard v-if="lecturers && lecturers.length > 0" :lecturers="lecturers"
-				:ratings="lecturerRatings" @lecturer-click="toLecturerPage" />
+			<TheLecturerSearchCompactCard
+				v-if="lecturers && lecturers.length > 0"
+				:lecturers="lecturers"
+				:ratings="lecturerRatings"
+				@lecturer-click="toLecturerPage"
+			/>
 			<div v-else class="ma-2">Ничего не нашли :(</div>
 		</div>
 
 		<!-- Пагинация и переключатель режима -->
 		<div v-if="lecturers && totalPages > 1" class="d-flex align-center justify-center mt-4">
-			<v-btn icon @click="isCompactView = !isCompactView" class="mr-2"
-				:title="isCompactView ? 'Обычный вид' : 'Компактный вид'">
+			<v-btn
+				icon
+				@click="isCompactView = !isCompactView"
+				class="mr-2"
+				:title="isCompactView ? 'Обычный вид' : 'Компактный вид'"
+			>
 				<v-icon>{{ isCompactView ? 'mdi-view-agenda' : 'mdi-table' }}</v-icon>
 			</v-btn>
 
-			<v-pagination v-model="page" active-color="primary" variant="elevated" :length="totalPages"
-				:total-visible="1" :show-first-last-page="true" ellipsis="" @update:model-value="loadLecturers" />
+			<v-pagination
+				v-model="page"
+				active-color="primary"
+				variant="elevated"
+				:length="totalPages"
+				:total-visible="1"
+				:show-first-last-page="true"
+				ellipsis=""
+				@update:model-value="loadLecturers"
+			/>
 		</div>
 	</v-container>
 </template>


### PR DESCRIPTION
## Изменения
Добавил компактное отображение списка преподов в виде таблицы с 10 элементами на странице. Сделал кнопку-свитчер между стандартным и компактным отображением.

## Детали реализации
1) Создал файл TheLecturerSearchCompactCard.vue, в котором реализована разметка через 'v-data-table', а также функции из карточки и функция для проверки и корректного отображения Null в графе предметов.
2) Добавил в MainPage.vue обработку случая TheLecturerSearchCompactCard.vue и кнопку переключения между TheLecturerSearchCompactCard.vue и стандартным отображением TheLecturerSearchCard.vue. Разместил эту кнопку слева от пагинации.

## Check-List
<!-- После сохранения у следующих полей появятся галочки, которые нужно проставить мышкой -->
- [ ] Вы проверили свой код перед отправкой запроса?
- [ ] Вы написали тесты к реализованным функциям?
- [ ] Вы не забыли применить форматирование `black` и `isort` для _Back-End_ или `Prettier` для _Front-End_?
